### PR TITLE
Bug fix regex to srl

### DIFF
--- a/imports/api/tokenize.js
+++ b/imports/api/tokenize.js
@@ -1,7 +1,7 @@
 import tokenize from 'regex-tokenizer';
 
 const patterns = [
-  { regex: /\(\?\:/, tag: "nonCapture" },
+  { regex: /\(\?\:/g, tag: "nonCapture" },
   { regex: /\[[^\]]*\]/g, tag: "charset" },
   { regex: /\{[0-9,]*\}/, tag: "count" },
   { regex: /\\./g, tag: "escaped" },

--- a/imports/api/translator.js
+++ b/imports/api/translator.js
@@ -11,7 +11,6 @@ export const regexToSrl = regex => {
   // throw error if invalid
   new RegExp(regex);
   const tree = createTree(regex);
-  console.log(tree);
   return traverseTree(tree);
 };
 
@@ -68,6 +67,8 @@ const traverseTree = node => {
     }
   });
 
+  console.warn(text);
+
   if (orGroup) {
     return "any of (" + combine(text) + ")";
   }
@@ -89,7 +90,12 @@ const combine = arr => {
     });
   }
 
+  chunks = flatten(chunks);
   return chunks.join(", ");
+};
+
+const flatten = array => {
+  return [].concat.apply([], array);
 };
 
 const isSelfContained = input => {
@@ -271,12 +277,11 @@ const charset = input => {
     return "any of (" + text.join(", ") + ")";
   }
 
-  return text.join("");
+  return text.join(" ");
 };
 
 const createTree = regex => {
   const tokens = tokenizeRegex(regex);
-  console.log(tokens);
   const root = new Node();
   let currentNode = root;
 

--- a/imports/components/translator/regex_input.jsx
+++ b/imports/components/translator/regex_input.jsx
@@ -64,6 +64,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(
         this.props.clearRegexInputErrors();
       } catch(error) {
         // If regex parsing fails, set errors
+        console.error(error);
         this.props.receiveRegexErrors(['Invalid regex syntax', error]);
       }
     }


### PR DESCRIPTION
Fixed a bug where multiple non-capturing groups were failing to translate. Global tag was missing from tokenizer.

Contents of an or'ed group _ex: `(?:[a-z]|[A-Z][0-9])`_ are now broken into parenthesized subgroups in order to keep terms together when needed.

Removes redundant parentheses when a non-capturing group contains a self-enclosing item so as to prevent accumulating groups.